### PR TITLE
Allow full installation via the Nix shell

### DIFF
--- a/updater/README.md
+++ b/updater/README.md
@@ -6,26 +6,17 @@ Please see the [contrib-updater documentation](./docs) to learn about the comman
 
 ## Installation
 
-First, ensure you have all necessary dependencies by entering a developer shell:
+The Nix shell provides all necessary dependencies and hooks for installing dependencies and building the tool. Start by entering the shell:
 
 ```sh
 nix-shell
 ```
 
-Then, build the executable by running the `build` script:
+You can now use `contrib-updater` to run the tool:
 
 ```sh
-npm run build
+contrib-updater --help
 ```
-
-Finally, run `npm link` to add the executable to your PATH:
-
-```sh
-# Nix restricts permissions, so sudo is required if inside the shell.
-sudo npm link
-```
-
-You can now use the `contrib-updater` executable.
 
 ## Usage
 

--- a/updater/shell.nix
+++ b/updater/shell.nix
@@ -19,4 +19,10 @@ in pkgs.stdenv.mkDerivation {
     pkgs.nodejs-12_x
     pkgs.dhall-json
   ];
+  executable = ./bin/index.js;
+  shellHook =''
+    npm install
+    npm run build
+    alias contrib-updater='${pkgs.nodejs-12_x}/bin/node ${./.}/bin/index.js'
+  '' ;
 }


### PR DESCRIPTION
Closes #4 by encapsulating installation into the Nix shell, which also includes runtime dependencies like `dhall-json`. You can now build and install the `contrib-updater` tool via `nix-shell`.

![demo](https://user-images.githubusercontent.com/10245104/91612347-1220d680-e932-11ea-9b78-c6e70e6bd8dd.gif)

It's still callable via `contrib-updater`, but the tool's name is displayed as 'index.js' in the help menus. I didn't want to spend too much time trying to make that nice, and this should allow folks to use the tool right away. Plus, subsequent updates to the tool can be matched with `npm run build` and your local version will be updated without effort as it's just a symlink to `./bin/index.js`.

cc: @JordanMartinez 