### PR TITLE
Support multiple maintainers, default titles in updater tool

### DIFF
--- a/updater/README.md
+++ b/updater/README.md
@@ -12,12 +12,6 @@ The Nix shell provides all necessary dependencies and hooks for installing depen
 nix-shell
 ```
 
-This will produce an `bin/index.js` file, which is the executable script. You can run commands using the path to this script. The easiest way to do so is by aliasing the full path:
-
-```sh
-alias contrib-updater="node $(readlink -f bin/index.js)"
-```
-
 You can now use `contrib-updater` to run the tool:
 
 ```sh

--- a/updater/docs/01-Generate.md
+++ b/updater/docs/01-Generate.md
@@ -10,7 +10,13 @@ The `generate` command will create a standard set of files in the current reposi
 
 This command is used to help manage migrating new libraries into the Contributors organization or to update existing libraries when our standard structure changes.
 
-Example CLI usage:
+Example CLI usage with defaults used (this is the typical case):
+
+```sh
+contrib-updater generate --maintainers thomashoneyman
+```
+
+Example CLI usage with all options specified:
 
 ```sh
 contrib-updater generate \
@@ -18,10 +24,10 @@ contrib-updater generate \
   # generated as well as the standard templates.
   --uses-js \
   --owner purescript-contrib \
-  --main-branch master \
+  --main-branch main \
   --display-name '`argonaut-codecs`' \
-  --title 'Argonaut Codecs' \
-  --maintainer thomashoneyman
+  --dislay-title 'Argonaut Codecs' \
+  --maintainers thomashoneyman
 ```
 
 In typical usage you will:
@@ -43,16 +49,16 @@ type Variables =
   , packageName :: String
   , displayName :: String
   , displayTitle :: String
-  , maintainer :: String
+  , maintainers :: NonEmptyList String
   }
 ```
 
 - `owner` refers to the owner of the repository being updated. Defaults in the CLI to `"purescript-contrib"`.
-- `mainBranch` refers to the primary branch used in the repository. Defaults in the CLI to `"main"`, but many libraries will need to use `"master"` instead.
+- `mainBranch` refers to the primary branch used in the repository. Defaults in the CLI to `"main"`, but some libraries may need to use `"master"` instead.
 - `packageName` refers to the package name as represented in the PureScript registry and Spago installation instructions. This is pulled automatically from the `spago.dhall` file.
 - `displayName` refers to the way you'd like to render the package name in markdown files. Defaults in the CLI to the name of the package in backticks, ie. `argonaut-codecs`, but it's also common to provide a string (for example, Argonaut Codecs) instead.
-- `displayTitle` refers to the way you'd like to render the package name in markdown titles. Defaults in the CLI to the name of the package without backtics, ie. argonaut-codecs, but it's also common to provide a string (for example, Argonaut Codecs) instead.
-- `maintainer` refers to the assigned maintainer for the library (ex: `"thomashoneyman"`). This is required in the CLI.
+- `displayTitle` refers to the way you'd like to render the package name in markdown titles. Defaults in the CLI to the name of the package in title case.
+- `maintainers` refers to the assigned maintainer(s) for the library (ex: `"thomashoneyman"`). This is required in the CLI.
 
 Any of these variables can be used in template files via `{{variableName}}` syntax. When templates are generated for a particular repository these variables will be replaced with the values you provided.
 

--- a/updater/docs/01-Generate.md
+++ b/updater/docs/01-Generate.md
@@ -26,7 +26,7 @@ contrib-updater generate \
   --owner purescript-contrib \
   --main-branch main \
   --display-name '`argonaut-codecs`' \
-  --dislay-title 'Argonaut Codecs' \
+  --display-title 'Argonaut Codecs' \
   --maintainers thomashoneyman
 ```
 

--- a/updater/docs/01-Generate.md
+++ b/updater/docs/01-Generate.md
@@ -13,7 +13,7 @@ This command is used to help manage migrating new libraries into the Contributor
 Example CLI usage with defaults used (this is the typical case):
 
 ```sh
-contrib-updater generate --maintainers thomashoneyman
+contrib-updater generate --maintainer garyb --maintainer thomashoneyman
 ```
 
 Example CLI usage with all options specified:
@@ -27,7 +27,7 @@ contrib-updater generate \
   --main-branch main \
   --display-name '`argonaut-codecs`' \
   --dislay-title 'Argonaut Codecs' \
-  --maintainers thomashoneyman
+  --maintainer thomashoneyman
 ```
 
 In typical usage you will:
@@ -49,7 +49,7 @@ type Variables =
   , packageName :: String
   , displayName :: String
   , displayTitle :: String
-  , maintainers :: NonEmptyList String
+  , maintainer :: NonEmptyList String
   }
 ```
 
@@ -58,7 +58,7 @@ type Variables =
 - `packageName` refers to the package name as represented in the PureScript registry and Spago installation instructions. This is pulled automatically from the `spago.dhall` file.
 - `displayName` refers to the way you'd like to render the package name in markdown files. Defaults in the CLI to the name of the package in backticks, ie. `argonaut-codecs`, but it's also common to provide a string (for example, Argonaut Codecs) instead.
 - `displayTitle` refers to the way you'd like to render the package name in markdown titles. Defaults in the CLI to the name of the package in title case.
-- `maintainers` refers to the assigned maintainer(s) for the library (ex: `"thomashoneyman"`). This is required in the CLI.
+- `maintainer` refers to the assigned maintainer(s) for the library (ex: `"thomashoneyman"`). This is required in the CLI.
 
 Any of these variables can be used in template files via `{{variableName}}` syntax. When templates are generated for a particular repository these variables will be replaced with the values you provided.
 

--- a/updater/packages.dhall
+++ b/updater/packages.dhall
@@ -2,3 +2,4 @@ let upstream =
       https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20200724/packages.dhall sha256:bb941d30820a49345a0e88937094d2b9983d939c9fd3a46969b85ce44953d7d9
 
 in  upstream
+  with strings-extra.version = "v2.2.0"

--- a/updater/shell.nix
+++ b/updater/shell.nix
@@ -24,5 +24,6 @@ in pkgs.stdenv.mkDerivation {
   shellHook =''
     npm install
     npm run build
+    alias contrib-updater="node $(readlink -f bin/index.js)"
   '' ;
 }

--- a/updater/spago.dhall
+++ b/updater/spago.dhall
@@ -5,12 +5,12 @@
   , "codec-argonaut"
   , "console"
   , "effect"
-  , "heterogeneous"
   , "interpolate"
   , "node-fs-aff"
   , "node-process"
   , "optparse"
   , "psci-support"
+  , "strings-extra"
   , "sunde"
   ]
 , packages = ./packages.dhall

--- a/updater/src/Updater/Cli.purs
+++ b/updater/src/Updater/Cli.purs
@@ -59,18 +59,18 @@ command = OA.hsubparser $ fold
       ]
 
     displayTitle <- optional $ OA.strOption $ fold
-      [ OA.long "title"
+      [ OA.long "display-title"
       , OA.metavar "STRING"
-      , OA.help "How to render this library's name in titles. Default: 'package-name'"
+      , OA.help "How to render this library's name in .md file titles. Default: 'Package Name'"
       ]
 
-    maintainer <- OA.strOption $ fold
-      [ OA.long "maintainer"
+    maintainers <- OA.some $ OA.strOption $ fold
+      [ OA.long "maintainers"
       , OA.metavar "STRING"
-      , OA.help "The assigned maintainer for this repository (required). Ex: 'thomashoneyman'"
+      , OA.help "The assigned maintainer(s) for this repository (required). Ex: 'thomashoneyman'"
       ]
 
-    in { usesJS, owner, mainBranch, displayName, displayTitle, maintainer }
+    in { usesJS, owner, mainBranch, displayName, displayTitle, maintainers }
 
 -- type SyncLabelsOptions =
 --   { token :: String

--- a/updater/src/Updater/Cli.purs
+++ b/updater/src/Updater/Cli.purs
@@ -65,7 +65,7 @@ command = OA.hsubparser $ fold
       ]
 
     maintainers <- OA.some $ OA.strOption $ fold
-      [ OA.long "maintainers"
+      [ OA.long "maintainer"
       , OA.metavar "STRING"
       , OA.help "The assigned maintainer(s) for this repository (required). Ex: 'thomashoneyman'"
       ]

--- a/updater/src/Updater/Command.purs
+++ b/updater/src/Updater/Command.purs
@@ -68,7 +68,7 @@ runGenerate opts = do
         <<< String.split (String.Pattern "-")
 
     maintainerTemplate maintainer =
-      i "[![Maintainer: " maintainer "](https://img.shields.io/badge/maintainer-" maintainer "-teal.svg)](http://github.com/" maintainer ")"
+      i "[![Maintainer: " maintainer "](https://img.shields.io/badge/maintainer-" maintainer "-teal.svg)](https://github.com/" maintainer ")"
 
     variables =
       { owner: fromMaybe "purescript-contrib" opts.owner

--- a/updater/src/Updater/Generate/Template.purs
+++ b/updater/src/Updater/Generate/Template.purs
@@ -49,7 +49,7 @@ replaceVariables vars contents = do
 
   -- Variables which admit only one value should be replaced inline:
   --
-  --   "This package is {{ packageName }} in the registry"
+  --   "This package is {{packageName}} in the registry"
   --   where packageName = my-package becomes
   --   "This package is my-package in the registry"
   replaceOne k v =
@@ -60,7 +60,7 @@ replaceVariables vars contents = do
   -- Variables which admit many values should be replaced multiple times with
   -- newlines in between:
   --
-  --   "{{ maintainers }}"
+  --   "{{maintainers}}"
   --   where maintainers = [ "a", "b" ] becomes
   --   "a\nb"
   replaceMany k vs =

--- a/updater/src/Updater/Generate/Template.purs
+++ b/updater/src/Updater/Generate/Template.purs
@@ -9,12 +9,12 @@ import Prelude
 import Control.Alternative ((<|>))
 import Data.Foldable (traverse_)
 import Data.Interpolate (i)
+import Data.List.NonEmpty as NEL
+import Data.List.Types (NonEmptyList)
 import Data.String as String
-import Data.Symbol (class IsSymbol, SProxy, reflectSymbol)
 import Effect.Aff (Aff)
 import Effect.Class (liftEffect)
 import Effect.Class.Console (log)
-import Heterogeneous.Folding (class FoldingWithIndex, class HFoldlWithIndex, hfoldlWithIndex)
 import Node.Encoding (Encoding(..))
 import Node.FS.Aff as FS
 import Node.FS.Aff.Extra as FS.Extra
@@ -30,29 +30,43 @@ type Variables =
   , packageName :: String
   , displayName :: String
   , displayTitle :: String
-  , maintainer :: String
+  , maintainers :: NonEmptyList String
   }
 
-data ReplaceVariables = ReplaceVariables
+-- | Replace each variable in the provided file contents, returning the updated
+-- | file to be written.
+replaceVariables :: Variables -> String -> String
+replaceVariables vars contents = do
+  contents
+    # replaceOne "owner" vars.owner
+    # replaceOne "mainBranch" vars.mainBranch
+    # replaceOne "packageName" vars.packageName
+    # replaceOne "displayName" vars.displayName
+    # replaceOne "displayTitle" vars.displayTitle
+    # replaceMany "maintainers" vars.maintainers
+  where
+  format str = i "{{" str "}}"
 
-instance replaceVariables' ::
-  IsSymbol sym =>
-  FoldingWithIndex ReplaceVariables (SProxy sym) String String String where
-  foldingWithIndex ReplaceVariables key acc val = do
-    replace (reflectSymbol key) val acc
-    where
-    -- | TODO: This find/replace method could probably be done better via `parsing`
-    replace k v = String.replaceAll (String.Pattern (format k)) (String.Replacement v)
-    format str = i "{{" str "}}"
+  -- Variables which admit only one value should be replaced inline:
+  --
+  --   "This package is {{ packageName }} in the registry"
+  --   where packageName = my-package becomes
+  --   "This package is my-package in the registry"
+  replaceOne k v =
+    String.replaceAll
+      (String.Pattern (format k))
+      (String.Replacement v)
 
--- | Given a file's contents and a record of variables to replace, replaces all
--- | variables in those contents.
-replaceVariables
-  :: HFoldlWithIndex ReplaceVariables String Variables String
-  => String
-  -> Variables
-  -> String
-replaceVariables = hfoldlWithIndex ReplaceVariables
+  -- Variables which admit many values should be replaced multiple times with
+  -- newlines in between:
+  --
+  --   "{{ maintainers }}"
+  --   where maintainers = [ "a", "b" ] becomes
+  --   "a\nb"
+  replaceMany k vs =
+    String.replaceAll
+      (String.Pattern (format k))
+      (String.Replacement (String.joinWith "\n" (NEL.toUnfoldable vs)))
 
 -- | Generate the standard templates for a PureScript Contributor project into
 -- | the correct file locations, backing up any existing files that would
@@ -139,7 +153,7 @@ runTemplate opts (Template { from, to }) = do
       FS.Extra.writeTextFile backupsPath existingContents
       FS.unlink to
 
-  FS.Extra.writeTextFile to (replaceVariables templateContents opts.variables)
+  FS.Extra.writeTextFile to (replaceVariables opts.variables templateContents)
 
 -- | The source and destination for a given template. Templates will be copied
 -- | from their source to destination, with text replacement applied along the way.

--- a/updater/templates/base/.editorconfig
+++ b/updater/templates/base/.editorconfig
@@ -1,4 +1,4 @@
-# http://editorconfig.org
+# https://editorconfig.org
 root = true
 
 [*]

--- a/updater/templates/base/README.md
+++ b/updater/templates/base/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/{{owner}}/purescript-{{packageName}}/workflows/CI/badge.svg?branch={{mainBranch}})](https://github.com/{{owner}}/purescript-{{packageName}}/actions?query=workflow%3ACI+branch%3A{{mainBranch}})
 [![Release](http://img.shields.io/github/release/{{owner}}/purescript-{{packageName}}.svg)](https://github.com/{{owner}}/purescript-{{packageName}}/releases)
 [![Pursuit](http://pursuit.purescript.org/packages/purescript-{{packageName}}/badge)](http://pursuit.purescript.org/packages/purescript-{{packageName}})
-[![Maintainer: {{maintainer}}](https://img.shields.io/badge/maintainer-{{maintainer}}-teal.svg)](http://github.com/{{maintainer}})
+{{maintainers}}
 
 The library summary hasn't been written yet (contributions are welcome!). The library summary describes the library's purpose in one to three sentences.
 

--- a/updater/templates/base/README.md
+++ b/updater/templates/base/README.md
@@ -1,8 +1,8 @@
 # {{displayTitle}}
 
 [![CI](https://github.com/{{owner}}/purescript-{{packageName}}/workflows/CI/badge.svg?branch={{mainBranch}})](https://github.com/{{owner}}/purescript-{{packageName}}/actions?query=workflow%3ACI+branch%3A{{mainBranch}})
-[![Release](http://img.shields.io/github/release/{{owner}}/purescript-{{packageName}}.svg)](https://github.com/{{owner}}/purescript-{{packageName}}/releases)
-[![Pursuit](http://pursuit.purescript.org/packages/purescript-{{packageName}}/badge)](http://pursuit.purescript.org/packages/purescript-{{packageName}})
+[![Release](https://img.shields.io/github/release/{{owner}}/purescript-{{packageName}}.svg)](https://github.com/{{owner}}/purescript-{{packageName}}/releases)
+[![Pursuit](https://pursuit.purescript.org/packages/purescript-{{packageName}}/badge)](https://pursuit.purescript.org/packages/purescript-{{packageName}})
 {{maintainers}}
 
 The library summary hasn't been written yet (contributions are welcome!). The library summary describes the library's purpose in one to three sentences.


### PR DESCRIPTION
This PR addresses a couple irritations with the updater tool, namely:

* The default value of `display-title` is now the title-cased package name, so this flag no longer needs to be specified for most packages (there are occasional exceptions, like "FreeT", which will incorrectly render "Freet" by default, and which you'll still have to manually specify the `--display-title` flag)
* You can now specify multiple GitHub usernames as maintainers (ie. `--maintainer garyb --maintainer thomashoneyman`) instead of manually fixing the underlying README file.

It also moves @milesfrain's alias command into the Nix shell so that the whole process runs with just `nix-shell` and you can get right to using `contrib-updater`. I verified this works for me with a fresh clone, but I'd appreciate someone else confirming they can clone this repo and run `nix-shell` and start using the tool just fine.