### PR TITLE
Auto-fill CHANGELOG.md file with past release info

### DIFF
--- a/updater/spago.dhall
+++ b/updater/spago.dhall
@@ -11,6 +11,7 @@
   , "optparse"
   , "psci-support"
   , "strings-extra"
+  , "stringutils"
   , "sunde"
   ]
 , packages = ./packages.dhall

--- a/updater/src/Updater/Cli.purs
+++ b/updater/src/Updater/Cli.purs
@@ -46,6 +46,12 @@ command = OA.hsubparser $ fold
       , OA.help "The owner of this repository. Default: purescript-contrib"
       ]
 
+    repo <- OA.strOption $ fold
+      [ OA.long "repo"
+      , OA.metavar "STRING"
+      , OA.help "The repository to use for updating the changelog. Ex: purescript-machines"
+      ]
+
     mainBranch <- optional $ OA.strOption $ fold
       [ OA.long "main-branch"
       , OA.metavar "STRING"
@@ -70,7 +76,7 @@ command = OA.hsubparser $ fold
       , OA.help "The assigned maintainer(s) for this repository (required). Ex: 'thomashoneyman'"
       ]
 
-    in { usesJS, owner, mainBranch, displayName, displayTitle, maintainers }
+    in { usesJS, owner, repo, mainBranch, displayName, displayTitle, maintainers }
 
 -- type SyncLabelsOptions =
 --   { token :: String

--- a/updater/src/Updater/Cli.purs
+++ b/updater/src/Updater/Cli.purs
@@ -46,7 +46,7 @@ command = OA.hsubparser $ fold
       , OA.help "The owner of this repository. Default: purescript-contrib"
       ]
 
-    repo <- OA.strOption $ fold
+    repo <- optional $ OA.strOption $ fold
       [ OA.long "repo"
       , OA.metavar "STRING"
       , OA.help "The repository to use for updating the changelog. Ex: purescript-machines"

--- a/updater/src/Updater/Command.purs
+++ b/updater/src/Updater/Command.purs
@@ -50,7 +50,7 @@ run = launchAff_ <<< case _ of
 type GenerateOptions =
   { usesJS :: Boolean
   , owner :: Maybe String
-  , repo :: String
+  , repo :: Maybe String
   , mainBranch :: Maybe String
   , displayName :: Maybe String
   , displayTitle :: Maybe String
@@ -74,7 +74,7 @@ runGenerate opts = do
 
     variables =
       { owner: fromMaybe "purescript-contrib" opts.owner
-      , repo: opts.repo
+      , repo: fromMaybe ("purescript-" <> spago.name) opts.repo
       , mainBranch: fromMaybe "main" opts.mainBranch
       , packageName: spago.name
       , displayName: fromMaybe ("`" <> spago.name <> "`") opts.displayName

--- a/updater/src/Updater/Command.purs
+++ b/updater/src/Updater/Command.purs
@@ -23,6 +23,7 @@ import Effect.Aff (Aff, launchAff_)
 import Effect.Aff as Aff
 import Effect.Class.Console (error, log)
 import Updater.Generate.Template (runBaseTemplates, runJsTemplates)
+import Updater.Generate.Changelog (appendReleaseInfoToChangelog)
 import Updater.SyncLabels.Request (IssueLabelRequestOpts)
 import Updater.SyncLabels.Request as SyncLabels
 import Updater.Utils.Dhall as Utils.Dhall
@@ -49,6 +50,7 @@ run = launchAff_ <<< case _ of
 type GenerateOptions =
   { usesJS :: Boolean
   , owner :: Maybe String
+  , repo :: String
   , mainBranch :: Maybe String
   , displayName :: Maybe String
   , displayTitle :: Maybe String
@@ -72,6 +74,7 @@ runGenerate opts = do
 
     variables =
       { owner: fromMaybe "purescript-contrib" opts.owner
+      , repo: opts.repo
       , mainBranch: fromMaybe "main" opts.mainBranch
       , packageName: spago.name
       , displayName: fromMaybe ("`" <> spago.name <> "`") opts.displayName
@@ -83,6 +86,8 @@ runGenerate opts = do
 
   when opts.usesJS do
     runJsTemplates variables
+
+  appendReleaseInfoToChangelog {owner: variables.owner, repo: spago.name }
 
   log
     """

--- a/updater/src/Updater/Command.purs
+++ b/updater/src/Updater/Command.purs
@@ -87,7 +87,7 @@ runGenerate opts = do
   when opts.usesJS do
     runJsTemplates variables
 
-  appendReleaseInfoToChangelog {owner: variables.owner, repo: spago.name }
+  appendReleaseInfoToChangelog { owner: variables.owner, repo: spago.name }
 
   log
     """

--- a/updater/src/Updater/Generate/Changelog.purs
+++ b/updater/src/Updater/Generate/Changelog.purs
@@ -45,7 +45,10 @@ appendReleaseInfoToChangelog gh = do
   let
     realReleases = filter (\r -> r.draft == false) releases
     appendContent = foldl addReleaseInfo "" realReleases
-  FSA.appendTextFile UTF8 "./CHANGELOG.md" appendContent
+  FSA.appendTextFile UTF8 "./CHANGELOG.md" $ joinWith "\n"
+    [ ""
+    , appendContent
+    ]
   where
     addReleaseInfo :: String -> ReleaseInfo -> String
     addReleaseInfo acc rec =

--- a/updater/src/Updater/Generate/Changelog.purs
+++ b/updater/src/Updater/Generate/Changelog.purs
@@ -4,14 +4,18 @@ import Prelude
 
 import Affjax as AX
 import Affjax.ResponseFormat as RF
+import Data.Array (filter, null)
 import Data.Codec (decode)
 import Data.Codec.Argonaut (JsonCodec, array, printJsonDecodeError)
 import Data.Codec.Argonaut as CA
 import Data.Codec.Argonaut.Record as CAR
 import Data.Either (Either(..))
 import Data.Foldable (foldl)
+import Data.Maybe (Maybe(..))
+import Data.Monoid (power)
 import Data.String.CodeUnits (takeWhile)
 import Data.String.Common (joinWith, trim)
+import Data.String.Utils (lines, startsWith)
 import Effect.Aff (Aff, error, throwError)
 import Node.Encoding (Encoding(..))
 import Node.FS.Aff as FSA
@@ -21,6 +25,7 @@ type ReleaseInfo =
   , html_url :: String
   , body :: String
   , published_at :: String
+  , draft :: Boolean
   }
 
 releaseCodec :: JsonCodec ReleaseInfo
@@ -30,13 +35,60 @@ releaseCodec =
     , html_url: CA.string
     , body: CA.string
     , published_at: CA.string
+    , draft: CA.boolean
     }
 
 appendReleaseInfoToChangelog :: forall r. { owner :: String, repo :: String | r } -> Aff Unit
 appendReleaseInfoToChangelog gh = do
+  releases <- recursivelyFetchReleases [] 1 gh
+  let
+    realReleases = filter (\r -> r.draft == false) releases
+    appendContent = foldl addReleaseInfo "" realReleases
+  FSA.appendTextFile UTF8 "./CHANGELOG.md" appendContent
+  where
+    addReleaseInfo :: String -> ReleaseInfo -> String
+    addReleaseInfo acc rec =
+      let
+        dateWithoutTimeZone = takeWhile (_ /= 'T') rec.published_at
+        bodyWithFixedHeaders = fixHeaders $ trim rec.body
+      in acc <> joinWith "\n"
+        [ "## [" <> rec.tag_name <> "](" <> rec.html_url <> ") - " <> dateWithoutTimeZone
+        , ""
+        , bodyWithFixedHeaders
+        , ""
+        , ""
+        ]
+
+    fixHeaders :: String -> String
+    fixHeaders s =
+      let
+        incAllHeaderLevels =
+          incHeaderlevel 5
+            >>> incHeaderlevel 4
+            >>> incHeaderlevel 3
+            >>> incHeaderlevel 2
+            >>> incHeaderlevel 1
+      in
+        joinWith "\n" $ map incAllHeaderLevels (lines s)
+
+    incHeaderlevel :: Int -> String -> String
+    incHeaderlevel level line =
+      if startsWith ((power "#" level) <> " ") line
+        then "#" <> line
+        else line
+
+recursivelyFetchReleases :: forall r. Array ReleaseInfo -> Int -> { owner :: String, repo :: String | r } -> Aff (Array ReleaseInfo)
+recursivelyFetchReleases accumulator page gh = do
+  pageNResult <- fetchNextPageOfReleases page gh
+  case pageNResult of
+    Nothing -> pure accumulator
+    Just arr -> recursivelyFetchReleases (accumulator <> arr) (page + 1) gh
+
+fetchNextPageOfReleases :: forall r. Int -> { owner :: String, repo :: String | r } -> Aff (Maybe (Array ReleaseInfo))
+fetchNextPageOfReleases page gh = do
   -- For example
   -- https://api.github.com/repos/purescript-contrib/purescript-http-methods/releases
-  let url = "https://api.github.com/repos/" <> gh.owner <> "/" <> gh.repo <> "/releases"
+  let url = "https://api.github.com/repos/" <> gh.owner <> "/" <> gh.repo <> "/releases?per_page=100&page=" <> show page
 
   result <- AX.get RF.json url
   case result of
@@ -46,18 +98,7 @@ appendReleaseInfoToChangelog gh = do
       case decode (array releaseCodec) body of
         Left e -> do
           throwError $ error $ printJsonDecodeError e
+        Right releases | null releases ->
+          pure Nothing
         Right releases -> do
-          let appendContent = foldl addReleaseInfo "" releases
-          FSA.appendTextFile UTF8 "./CHANGELOG.md" appendContent
-
-  where
-    addReleaseInfo :: String -> ReleaseInfo -> String
-    addReleaseInfo acc rec =
-      let dateWithoutTimeZone = takeWhile (_ /= 'T') rec.published_at
-      in acc <> joinWith "\n"
-        [ "## [" <> rec.tag_name <> "](" <> rec.html_url <> ") - " <> dateWithoutTimeZone
-        , ""
-        , trim rec.body
-        , ""
-        , ""
-        ]
+          pure $ Just releases

--- a/updater/src/Updater/Generate/Changelog.purs
+++ b/updater/src/Updater/Generate/Changelog.purs
@@ -1,0 +1,58 @@
+module Updater.Generate.Changelog where
+
+import Prelude
+
+import Affjax as AX
+import Affjax.ResponseFormat as RF
+import Data.Codec (decode)
+import Data.Codec.Argonaut (JsonCodec, array, printJsonDecodeError)
+import Data.Codec.Argonaut as CA
+import Data.Codec.Argonaut.Record as CAR
+import Data.Either (Either(..))
+import Data.Foldable (fold, for_)
+import Data.String.CodeUnits (takeWhile)
+import Data.String.Common (joinWith, trim)
+import Effect.Aff (Aff, error, throwError)
+import Node.Encoding (Encoding(..))
+import Node.FS.Aff as FSA
+
+type ReleaseInfo =
+  { tag_name :: String
+  , html_url :: String
+  , body :: String
+  , published_at :: String
+  }
+
+releaseCodec :: JsonCodec ReleaseInfo
+releaseCodec =
+  CAR.object "ReleaseInfo" $
+    { tag_name: CA.string
+    , html_url: CA.string
+    , body: CA.string
+    , published_at: CA.string
+    }
+
+appendReleaseInfoToChangelog :: forall r. { owner :: String, repo :: String | r } -> Aff Unit
+appendReleaseInfoToChangelog gh = do
+  -- For example
+  -- https://api.github.com/repos/purescript-contrib/purescript-http-methods/releases
+  let url = "https://api.github.com/repos/" <> gh.owner <> "/" <> gh.repo <> "/releases"
+
+  result <- AX.get RF.json url
+  case result of
+    Left err -> do
+      throwError (error $ AX.printError err)
+    Right { body } ->
+      case decode (array releaseCodec) body of
+        Left e -> do
+          throwError $ error $ printJsonDecodeError e
+        Right releases -> do
+          for_ releases \rec -> do
+            let dateWithoutTimeZone = takeWhile (_ /= 'T') rec.published_at
+            FSA.appendTextFile UTF8 "./CHANGELOG.md" $ joinWith "\n"
+              [ "## [" <> rec.tag_name <> "](" <> rec.html_url <> ") - " <> dateWithoutTimeZone
+              , ""
+              , trim rec.body
+              , ""
+              , ""
+              ]

--- a/updater/src/Updater/Generate/Changelog.purs
+++ b/updater/src/Updater/Generate/Changelog.purs
@@ -13,9 +13,10 @@ import Data.Either (Either(..))
 import Data.Foldable (foldl)
 import Data.Maybe (Maybe(..))
 import Data.Monoid (power)
-import Data.String.CodeUnits (takeWhile)
+import Data.String (Pattern(..))
+import Data.String.CodeUnits (drop, indexOf, length, takeWhile)
 import Data.String.Common (joinWith, trim)
-import Data.String.Utils (lines, startsWith)
+import Data.String.Utils (lines)
 import Effect.Aff (Aff, error, throwError)
 import Node.Encoding (Encoding(..))
 import Node.FS.Aff as FSA
@@ -62,20 +63,22 @@ appendReleaseInfoToChangelog gh = do
     fixHeaders :: String -> String
     fixHeaders s =
       let
-        incAllHeaderLevels =
-          incHeaderlevel 5
-            >>> incHeaderlevel 4
-            >>> incHeaderlevel 3
-            >>> incHeaderlevel 2
-            >>> incHeaderlevel 1
+        replaceAllHeaders =
+          replaceHeaderWithBoldedText 5
+            >>> replaceHeaderWithBoldedText 4
+            >>> replaceHeaderWithBoldedText 3
+            >>> replaceHeaderWithBoldedText 2
+            >>> replaceHeaderWithBoldedText 1
       in
-        joinWith "\n" $ map incAllHeaderLevels (lines s)
+        joinWith "\n" $ map replaceAllHeaders (lines s)
 
-    incHeaderlevel :: Int -> String -> String
-    incHeaderlevel level line =
-      if startsWith ((power "#" level) <> " ") line
-        then "#" <> line
-        else line
+    replaceHeaderWithBoldedText :: Int -> String -> String
+    replaceHeaderWithBoldedText level line =
+      let
+        prefix = (power "#" level) <> " "
+      in case indexOf (Pattern prefix) line of
+        Nothing -> line
+        Just _ -> "**" <> drop (length prefix) line <> "**"
 
 recursivelyFetchReleases :: forall r. Array ReleaseInfo -> Int -> { owner :: String, repo :: String | r } -> Aff (Array ReleaseInfo)
 recursivelyFetchReleases accumulator page gh = do

--- a/updater/src/Updater/Generate/Template.purs
+++ b/updater/src/Updater/Generate/Template.purs
@@ -31,6 +31,7 @@ type Variables =
   , displayName :: String
   , displayTitle :: String
   , maintainers :: NonEmptyList String
+  , repo :: String -- not used
   }
 
 -- | Replace each variable in the provided file contents, returning the updated

--- a/updater/templates/base/CHANGELOG.md
+++ b/updater/templates/base/CHANGELOG.md
@@ -11,5 +11,3 @@ New features:
 Bugfixes:
 
 Other improvements:
-
-## [0.0.0] - 2020-01-01

--- a/updater/templates/base/CHANGELOG.md
+++ b/updater/templates/base/CHANGELOG.md
@@ -11,3 +11,5 @@ New features:
 Bugfixes:
 
 Other improvements:
+
+

--- a/updater/templates/base/CHANGELOG.md
+++ b/updater/templates/base/CHANGELOG.md
@@ -11,5 +11,3 @@ New features:
 Bugfixes:
 
 Other improvements:
-
-


### PR DESCRIPTION
Fixes #22

A few thoughts
- The `appendReleaseInfo` function assumes that the CHANGELOG.md file was created in the `runBaseTemplates` call. In other words, the file creation and file appending don't occur within the same block together to prevent later separation. I don't like this, but I'm not sure whether it's worth it to refactor that
- A new CLI argument is now required on the `contrib-updater` tool: `repo` since I'm not sure whether we can always guarantee that the repo's name on GH matches the Spago name in the `spago.dhall` file.