### PR TITLE
Use the provided repository flag in README template

### DIFF
--- a/updater/docs/01-Generate.md
+++ b/updater/docs/01-Generate.md
@@ -24,6 +24,7 @@ contrib-updater generate \
   # generated as well as the standard templates.
   --uses-js \
   --owner purescript-contrib \
+  --repo purescript-argonaut-codecs \
   --main-branch main \
   --display-name '`argonaut-codecs`' \
   --display-title 'Argonaut Codecs' \
@@ -50,12 +51,14 @@ type Variables =
   , displayName :: String
   , displayTitle :: String
   , maintainer :: NonEmptyList String
+  , repo :: String
   }
 ```
 
 - `owner` refers to the owner of the repository being updated. Defaults in the CLI to `"purescript-contrib"`.
 - `mainBranch` refers to the primary branch used in the repository. Defaults in the CLI to `"main"`, but some libraries may need to use `"master"` instead.
 - `packageName` refers to the package name as represented in the PureScript registry and Spago installation instructions. This is pulled automatically from the `spago.dhall` file.
+- `repo` refers to the repository containing the package. Defaults in the CLI to `"purescript-{{packageName}}"`, re-using the package name as represented in the PureScript registry.
 - `displayName` refers to the way you'd like to render the package name in markdown files. Defaults in the CLI to the name of the package in backticks, ie. `argonaut-codecs`, but it's also common to provide a string (for example, Argonaut Codecs) instead.
 - `displayTitle` refers to the way you'd like to render the package name in markdown titles. Defaults in the CLI to the name of the package in title case.
 - `maintainer` refers to the assigned maintainer(s) for the library (ex: `"thomashoneyman"`). This is required in the CLI.

--- a/updater/src/Updater/Generate/Template.purs
+++ b/updater/src/Updater/Generate/Template.purs
@@ -31,7 +31,7 @@ type Variables =
   , displayName :: String
   , displayTitle :: String
   , maintainers :: NonEmptyList String
-  , repo :: String -- not used
+  , repo :: String
   }
 
 -- | Replace each variable in the provided file contents, returning the updated
@@ -44,6 +44,7 @@ replaceVariables vars contents = do
     # replaceOne "packageName" vars.packageName
     # replaceOne "displayName" vars.displayName
     # replaceOne "displayTitle" vars.displayTitle
+    # replaceOne "repo" vars.repo
     # replaceMany "maintainers" vars.maintainers
   where
   format str = i "{{" str "}}"

--- a/updater/templates/base/README.md
+++ b/updater/templates/base/README.md
@@ -1,8 +1,8 @@
 # {{displayTitle}}
 
-[![CI](https://github.com/{{owner}}/purescript-{{packageName}}/workflows/CI/badge.svg?branch={{mainBranch}})](https://github.com/{{owner}}/purescript-{{packageName}}/actions?query=workflow%3ACI+branch%3A{{mainBranch}})
-[![Release](https://img.shields.io/github/release/{{owner}}/purescript-{{packageName}}.svg)](https://github.com/{{owner}}/purescript-{{packageName}}/releases)
-[![Pursuit](https://pursuit.purescript.org/packages/purescript-{{packageName}}/badge)](https://pursuit.purescript.org/packages/purescript-{{packageName}})
+[![CI](https://github.com/{{owner}}/{{repo}}/workflows/CI/badge.svg?branch={{mainBranch}})](https://github.com/{{owner}}/{{repo}}/actions?query=workflow%3ACI+branch%3A{{mainBranch}})
+[![Release](https://img.shields.io/github/release/{{owner}}/{{repo}}.svg)](https://github.com/{{owner}}/{{repo}}/releases)
+[![Pursuit](https://pursuit.purescript.org/packages/{{repo}}/badge)](https://pursuit.purescript.org/packages/{{repo}})
 {{maintainers}}
 
 The library summary hasn't been written yet (contributions are welcome!). The library summary describes the library's purpose in one to three sentences.
@@ -23,20 +23,20 @@ The quick start hasn't been written yet (contributions are welcome!). The quick 
 
 {{displayName}} documentation is stored in a few places:
 
-1. Module documentation is [published on Pursuit](https://pursuit.purescript.org/packages/purescript-{{packageName}}).
+1. Module documentation is [published on Pursuit](https://pursuit.purescript.org/packages/{{repo}}).
 2. Written documentation is kept in the [docs directory](./docs).
 3. Usage examples can be found in [the test suite](./test).
 
 If you get stuck, there are several ways to get help:
 
-- [Open an issue](https://github.com/{{owner}}/purescript-{{packageName}}/issues) if you have encountered a bug or problem.
+- [Open an issue](https://github.com/{{owner}}/{{repo}}/issues) if you have encountered a bug or problem.
 - [Search or start a thread on the PureScript Discourse](https://discourse.purescript.org) if you have general questions. You can also ask questions in the `#purescript` and `#purescript-beginners` channels on the [Functional Programming Slack](https://functionalprogramming.slack.com) ([invite link](https://fpchat-invite.herokuapp.com/)).
 
 ## Contributing
 
 You can contribute to {{displayName}} in several ways:
 
-1. If you encounter a problem or have a question, please [open an issue](https://github.com/{{owner}}/purescript-{{packageName}}/issues). We'll do our best to work with you to resolve or answer it.
+1. If you encounter a problem or have a question, please [open an issue](https://github.com/{{owner}}/{{repo}}/issues). We'll do our best to work with you to resolve or answer it.
 
 2. If you would like to contribute code, tests, or documentation, please [read the contributor guide](./CONTRIBUTING.md). It's a short, helpful introduction to contributing to this library, including development instructions.
 

--- a/updater/templates/base/README.md
+++ b/updater/templates/base/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/{{owner}}/{{repo}}/workflows/CI/badge.svg?branch={{mainBranch}})](https://github.com/{{owner}}/{{repo}}/actions?query=workflow%3ACI+branch%3A{{mainBranch}})
 [![Release](https://img.shields.io/github/release/{{owner}}/{{repo}}.svg)](https://github.com/{{owner}}/{{repo}}/releases)
-[![Pursuit](https://pursuit.purescript.org/packages/{{repo}}/badge)](https://pursuit.purescript.org/packages/{{repo}})
+[![Pursuit](https://pursuit.purescript.org/packages/purescript-{{packageName}}/badge)](https://pursuit.purescript.org/packages/purescript-{{packageName}})
 {{maintainers}}
 
 The library summary hasn't been written yet (contributions are welcome!). The library summary describes the library's purpose in one to three sentences.
@@ -23,7 +23,7 @@ The quick start hasn't been written yet (contributions are welcome!). The quick 
 
 {{displayName}} documentation is stored in a few places:
 
-1. Module documentation is [published on Pursuit](https://pursuit.purescript.org/packages/{{repo}}).
+1. Module documentation is [published on Pursuit](https://pursuit.purescript.org/packages/purescript-{{packageName}}).
 2. Written documentation is kept in the [docs directory](./docs).
 3. Usage examples can be found in [the test suite](./test).
 


### PR DESCRIPTION
This is a followup to #25, which introduced a `--repo` CLI flag. This PR uses the `repo` variable everywhere we refer to a package's repository, ie. the README badges, Pursuit links, and so on. Previously this was hardcoded as `purescript-{{packageName}}`. Now, it's the `{{repo}}` variable, which by default is `purescript-{{packageName}}`.