### PR TITLE
New guidelines: changelog in root. Simplify numbering.

### DIFF
--- a/library-guidelines.md
+++ b/library-guidelines.md
@@ -7,10 +7,11 @@ This short handbook outlines the mimimum expectations for libraries in the PureS
 Libraries in the Contributors organization are expected to:
 
 1. Have at least one (and preferably more) assigned maintainers, as indicated by badges in the project README.
-2. Have adequate documentation in the form of module documentation published to Pursuit, a README containing a library summary, installation instructions, and more, and a `docs` directory containing at least a short tutorial and a changelog (see [the documentation section below](#documentation)).
-3. Have an adequate test suite which is exercised by continuous integration (see [the tests section below](#tests))
-4. Use the standard Contributors repository structure, which can be generated with the [contrib-updater](./updater) tool (see [the repository structure section below](#repository-structure)).
-5. Use a default branch of `main` for the repository.
+1. Have adequate documentation in the form of module documentation published to Pursuit, a README containing a library summary, installation instructions, and more, and a `docs` directory containing at least a short tutorial (see [the documentation section below](#documentation)).
+1. Have a CHANGELOG.md in the root directory.
+1. Have an adequate test suite which is exercised by continuous integration (see [the tests section below](#tests))
+1. Use the standard Contributors repository structure, which can be generated with the [contrib-updater](./updater) tool (see [the repository structure section below](#repository-structure)).
+1. Use a default branch of `main` for the repository.
 
 Libraries in this organization should be useful, tested, and well-documented. These are great things to shoot for in any library, but Contributors libraries are held to a particular standard to encourage new contributions and to serve as an example for other libraries in the community.
 
@@ -19,8 +20,8 @@ Libraries in this organization should be useful, tested, and well-documented. Th
 Contributors libraries are expected to have adequate documentation. To accomplish that goal, we expect each repository to have:
 
 1. A repository README containing badges for the build status, latest release, and maintainers, a short summary of the library's purpose, installation instructions, a quick start with a minimal usage example, and links to the documentation and contributing guide
-2. Expanded documentation like how-tos, tutorials, and concept overviews in the docs directory (at minimum a short tutorial that expands on the quick start), along with a CHANGELOG.md file
-3. Documentation comments for the majority and preferably all publicly-exported types and functions in the library modules, which should should be uploaded to Pursuit.
+1. Expanded documentation like how-tos, tutorials, and concept overviews in the docs directory (at minimum a short tutorial that expands on the quick start).
+1. Documentation comments for the majority and preferably all publicly-exported types and functions in the library modules, which should should be uploaded to Pursuit.
 
 If you are migrating a library to the Contributors organization (or creating an new one), the [contrib-updater](./updater) tool can generate templates on your behalf to help you get started with documentation.
 
@@ -29,7 +30,7 @@ If you are migrating a library to the Contributors organization (or creating an 
 Contributors libraries are expected to have tests which exercise tricky parts of the code and serve as usage examples. These tests should help maintainers merge pull requests which pass CI with confidence. We expect each repository to have:
 
 1. One or more tests in a `test` directory
-2. Continuous integration via GitHub Actions which exercises this test on pull requests and the main branch
+1. Continuous integration via GitHub Actions which exercises this test on pull requests and the main branch
 
 ### Repository Structure
 
@@ -45,7 +46,7 @@ Some of these files can be customized per-repository, but most of them are stand
 
 Each library also contains some standard directories, including:
 
-- A `docs` directory containing a changelog and any other expanded documentation for the library such as tutorials and walkthroughs
+- A `docs` directory containing expanded documentation for the library such as tutorials and walkthroughs.
 - A `.github` directory containing issue templates, pull request templates, contributing guide, and workflows for tests in continuous integration and automatically labeling stale issues and pull requests.
 
 #### Standard Labels
@@ -69,8 +70,8 @@ Maintainers are expected to ensure that libraries they maintain meet the minimum
 In addition, maintainers are expected to:
 
 1. Interact with users of the library promptly and respectfully. Maintainers should respond to issues and pull requests quickly -- even if that response is a simple request for more information or to add a 'help wanted' label. Contributors should feel respected, heard, and motivated to contribute more.
-2. Merge contributions of that are of sufficient quality. Pull requests should pass CI and should include adequate tests, documentation, and be reflected in the changelog. Pull requests that meet these criteria and are beneficial to the library should be merged.
-3. Curate the issue tracker and repository contents. Maintainers should apply labels to issues, close old issues, and ensure that documentation adequately helps users get started with new contributions. If you notice a way to make the repository more accessible to newcomers, open and label an issue that describes how the project could be improved!
+1. Merge contributions of that are of sufficient quality. Pull requests should pass CI and should include adequate tests, documentation, and be reflected in the changelog. Pull requests that meet these criteria and are beneficial to the library should be merged.
+1. Curate the issue tracker and repository contents. Maintainers should apply labels to issues, close old issues, and ensure that documentation adequately helps users get started with new contributions. If you notice a way to make the repository more accessible to newcomers, open and label an issue that describes how the project could be improved!
 
 Maintainers aren't necessarily expected to actively contribute code to the projects they maintain. They _are_ expected to keep the repository up to date, to respond quickly to issues and pull requests, and to curate issues in the issue tracker.
 
@@ -87,4 +88,4 @@ You can also ping other maintainers on the PureScript Discourse or the functiona
 Yes! We regularly accept new libraries to become a part of `purescript-contrib`. Libraries in the organization benefit from shared maintenance and greater visibility to new contributors. However, so that we don't become overwhelmed with projects to maintain, we do have some ground rules for new libraries.
 
 1. Your library must have at least one person committed to maintaining it. Others will help once it's in the organization, but we don't have the bandwidth to totally take over maintenance of new projects.
-2. Your library should meet the minimum requirements as outlined for all Contributors libraries in this post. If you need help updating your library to meet these requirements, we can help you.
+1. Your library should meet the minimum requirements as outlined for all Contributors libraries in this post. If you need help updating your library to meet these requirements, we can help you.


### PR DESCRIPTION
Follow-up to #20 where changelog is now in root.

Also, using all `1.`s in numbered lists makes it easier to add/remove/reorder entries.