### PR TITLE
Consolidate label descriptions

### DIFF
--- a/library-guidelines.md
+++ b/library-guidelines.md
@@ -51,17 +51,7 @@ Each library also contains some standard directories, including:
 
 #### Standard Labels
 
-Labels are a big part of curating the issue tracker in a Contributors library. Labels are regularly, automatically synced via the [contrib-updater](./updater) CLI tool, which will set labels, colors, and descriptions across repositories.
-
-We use several standard labels for issues of various types:
-
-- `bug` is used for issues that point out a legitimate bug in the library that ought to be fixed
-- `document me` is used for issues that indicate documentation needs to be updated, or for issues with great content that ought to be added to the documentation.
-- `enhancement` is used for issues or pull requests that represent an addition to the library
-- `good first issue` is used to label tasks that are good for beginners to take on. This is one of the best ways to encourage new contributions to the PureScript ecosystem!
-- `help wanted` is used as a call to action to indicate that the maintainers would like a PR that solves this issue.
-
-Further issues can be found on [this repository's issue labels page](https://github.com/purescript-contrib/governance/issues/labels).
+Labels are a big part of curating the issue tracker in a Contributors library. Labels are regularly and automatically synced via the [contrib-updater](./updater) CLI tool, which will set labels, colors, and descriptions across repositories. We use several standard labels for issues of various types. They can be found on [this repository's issue labels page](https://github.com/purescript-contrib/governance/issues/labels). For instructions on how to update labels across all Contributor libraries see the [Sync Labels documentation](./updater/docs/02-Sync-Labels.md).
 
 ## Expectations for Maintainers
 

--- a/updater/docs/02-Sync-Labels.md
+++ b/updater/docs/02-Sync-Labels.md
@@ -30,4 +30,4 @@ Successfully completed syncing labels.
 
 ## Updating Labels
 
-The set of labels used in the Contributors libraries is maintained by the `SyncLabels` command and should be updated in the source code if you need to make a change.
+The set of labels used in the Contributors libraries is maintained by the `SyncLabels` command and should be updated in the [source code](../src/Updater/SyncLabels/IssueLabel.purs) if you need to make a change.

--- a/updater/src/Updater/SyncLabels/IssueLabel.purs
+++ b/updater/src/Updater/SyncLabels/IssueLabel.purs
@@ -35,11 +35,11 @@ issueLabelCodec =
 labels :: Array IssueLabel
 labels =
   [ { name: "breaking change"
-    , description: "Change will require a major version bump"
+    , description: "A change that requires a major version bump"
     , color: "e99695"
     }
   , { name: "bug"
-    , description: "Something isn't working"
+    , description: "A legitimate bug in the library that ought to be fixed"
     , color: "d73a4a"
     }
   , { name: "document me"
@@ -47,7 +47,7 @@ labels =
     , color: "0075ca"
     }
   , { name: "enhancement"
-    , description: "New feature or request"
+    , description: "An addition to the library"
     , color: "a6e1ea"
     }
   , { name: "good first issue"
@@ -55,7 +55,7 @@ labels =
     , color: "7057ff"
     }
   , { name: "help wanted"
-    , description: "Extra attention is needed"
+    , description: "Maintainers would like a PR that solves this issue"
     , color: "006b75"
     }
   , { name: "question"

--- a/updater/src/Updater/SyncLabels/IssueLabel.purs
+++ b/updater/src/Updater/SyncLabels/IssueLabel.purs
@@ -55,7 +55,7 @@ labels =
     , color: "7057ff"
     }
   , { name: "help wanted"
-    , description: "Maintainers would like a PR that solves this issue"
+    , description: "Maintainers would like assistance with solving this issue"
     , color: "006b75"
     }
   , { name: "question"


### PR DESCRIPTION
Was originally confused by what "help wanted - extra attention is needed" means, so did some digging and landed on https://github.com/purescript-contrib/governance/blob/main/library-guidelines.md#standard-labels

The descriptions in the guidelines doc are a lot clearer, so why not just some of those for the actual label descriptions too? Hopefully they fit in the tooltips.

Not attached to any particular wording for the label descriptions, but wanted to make a few edits to facilitate discussion.

We also risk label descriptions becoming out of sync, since they exist in multiple locations. This already started with `breaking change` and `question` missing from the library guidelines. I think things will be easier to maintain if we just point to the label listings in the `.purs` code from the library guidelines.