### PR TITLE
`list-labels` command: render color; print repo number

### DIFF
--- a/updater/src/Updater/SyncLabels/IssueLabel.purs
+++ b/updater/src/Updater/SyncLabels/IssueLabel.purs
@@ -1,11 +1,14 @@
 module Updater.SyncLabels.IssueLabel where
 
+import Prelude
+
 import Data.Argonaut.Core (Json, fromString, isString)
 import Data.Codec ((<~<))
 import Data.Codec.Argonaut as CA
 import Data.Codec.Argonaut.Migration as CAM
 import Data.Codec.Argonaut.Record as CAR
 import Data.Maybe (Maybe(..))
+import Data.String (drop)
 
 -- | A GitHub issue label consisting of three parts:
 -- |
@@ -33,33 +36,33 @@ issueLabelCodec =
 
 -- | The full set of issue labels supported by Contributor libraries.
 labels :: Array IssueLabel
-labels =
+labels = map (\r -> r { color = drop 1 r.color })
   [ { name: "breaking change"
     , description: "A change that requires a major version bump"
-    , color: "e99695"
+    , color: "#e99695"
     }
   , { name: "bug"
     , description: "A legitimate bug in the library that ought to be fixed"
-    , color: "d73a4a"
+    , color: "#d73a4a"
     }
   , { name: "document me"
     , description: "Improvements or additions to documentation"
-    , color: "0075ca"
+    , color: "#0075ca"
     }
   , { name: "enhancement"
     , description: "An addition to the library"
-    , color: "a6e1ea"
+    , color: "#a6e1ea"
     }
   , { name: "good first issue"
     , description: "Good for newcomers"
-    , color: "7057ff"
+    , color: "#7057ff"
     }
   , { name: "help wanted"
     , description: "Maintainers would like assistance with solving this issue"
-    , color: "006b75"
+    , color: "#006b75"
     }
   , { name: "question"
     , description: "Question that needs an answer"
-    , color: "fbca04"
+    , color: "#fbca04"
     }
   ]

--- a/updater/src/Updater/SyncLabels/Request.purs
+++ b/updater/src/Updater/SyncLabels/Request.purs
@@ -109,8 +109,8 @@ listAllLabels token = do
             <> [ "" ]
 
         foldFn2 acc (Tuple r repos) = acc <>
-          [ i "Color: " r.color " | Description: " r.description
-          , i " ↳ Repos: " $ show repos
+          [ i "Color: #" r.color " | Description: " r.description
+          , i " ↳ Repos (" (Array.length repos) "): " $ show repos
           ]
 
       labelAppearancesInRepos = foldlWithIndex foldFn [] labelMap.labels


### PR DESCRIPTION
Follow up to #47 

By adding the `#` character in front of the color, I can see the results in a file, `results.txt`, when viewing the file in VS Code using [vscode-ext-color-highlight](https://github.com/enyancc/vscode-ext-color-highlight):
```
contrib-updater list-labels --token TOKEN &> results.txt
```

![Screenshot from 2021-11-19 21-07-11](https://user-images.githubusercontent.com/8413037/142715190-b741afd0-2c49-4d2d-9215-2ee49cc97503.png)

This PR also adds the number of repos that share a given metadata diff